### PR TITLE
feat: Enhance HalfDepthBoardEvaluator for overlapping emtpy square

### DIFF
--- a/src/backend/TikTakToe.Tests/engines/HalfDepthEngineTest.cs
+++ b/src/backend/TikTakToe.Tests/engines/HalfDepthEngineTest.cs
@@ -85,6 +85,38 @@ public class HalfDepthBoardEvaluatorTest
     }
 
     [Fact]
+    public void Eval_OverlappingThreatsOnSameSquare_CountsOnce()
+    {
+        var evaluator = new HalfDepthBoardEvaluator();
+        var board = new int[3, 3]
+        {
+            { 0, 1, 0 },
+            { 1, 0, 1 },
+            { 0, 1, 0 }
+        };
+
+        var score = evaluator.Evaluate(board);
+
+        Assert.Equal(500, score);
+    }
+
+    [Fact]
+    public void Eval_TwoThreatsOnDifferentSquares_ScoresAs1000()
+    {
+        var evaluator = new HalfDepthBoardEvaluator();
+        var board = new int[3, 3]
+        {
+            { 1, 1, 0 },
+            { 0, 0, 0 },
+            { 1, 1, 0 }
+        };
+
+        var score = evaluator.Evaluate(board);
+
+        Assert.Equal(1000, score);
+    }
+
+    [Fact]
     public void Eval_NonTerminalBoard_ReturnsHeuristicInRange()
     {
         var evaluator = new HalfDepthBoardEvaluator();

--- a/src/backend/TikTakToe/Engines/Evaluation/HalfDepthBoardEvaluator.cs
+++ b/src/backend/TikTakToe/Engines/Evaluation/HalfDepthBoardEvaluator.cs
@@ -30,36 +30,119 @@ public sealed class HalfDepthBoardEvaluator : IBoardEvaluator
                 score -= 500;
             }
         }
+        if (board[0, 0] == 0)
+        {
+            if ((board[0, 1] == 1 && board[0, 2] == 1) ||
+                (board[1, 0] == 1 && board[2, 0] == 1))
+            {
+                score += 500;
+            }
 
-        // Rows
-        score += TwoInRowScore(board[0, 0], board[0, 1], board[0, 2]);
-        score += TwoInRowScore(board[1, 0], board[1, 1], board[1, 2]);
-        score += TwoInRowScore(board[2, 0], board[2, 1], board[2, 2]);
+            if ((board[0, 1] == 2 && board[0, 2] == 2) ||
+                (board[1, 0] == 2 && board[2, 0] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[0, 1] == 0)
+        {
+            if ((board[0, 0] == 1 && board[0, 2] == 1) ||
+                (board[1, 1] == 1 && board[2, 1] == 1))
+            {
+                score += 500;
+            }
 
-        // Columns
-        score += TwoInRowScore(board[0, 0], board[1, 0], board[2, 0]);
-        score += TwoInRowScore(board[0, 1], board[1, 1], board[2, 1]);
-        score += TwoInRowScore(board[0, 2], board[1, 2], board[2, 2]);
+            if ((board[0, 0] == 2 && board[0, 2] == 2) ||
+                (board[1, 1] == 2 && board[2, 1] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[0, 2] == 0)
+        {
+            if ((board[0, 0] == 1 && board[0, 1] == 1) ||
+                (board[1, 2] == 1 && board[2, 2] == 1))
+            {
+                score += 500;
+            }
 
+            if ((board[0, 0] == 2 && board[0, 1] == 2) ||
+                (board[1, 2] == 2 && board[2, 2] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[1, 0] == 0)
+        {
+            if ((board[0, 0] == 1 && board[2, 0] == 1) ||
+                (board[1, 1] == 1 && board[1, 2] == 1))
+            {
+                score += 500;
+            }
+
+            if ((board[0, 0] == 2 && board[2, 0] == 2) ||
+                (board[1, 1] == 2 && board[1, 2] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[1, 2] == 0)
+        {
+            if ((board[0, 2] == 1 && board[2, 2] == 1) ||
+                (board[1, 0] == 1 && board[1, 1] == 1))
+            {
+                score += 500;
+            }
+
+            if ((board[0, 2] == 2 && board[2, 2] == 2) ||
+                (board[1, 0] == 2 && board[1, 1] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[2, 0] == 0)
+        {
+            if ((board[0, 0] == 1 && board[1, 0] == 1) ||
+                (board[2, 1] == 1 && board[2, 2] == 1))
+            {
+                score += 500;
+            }
+
+            if ((board[0, 0] == 2 && board[1, 0] == 2) ||
+                (board[2, 1] == 2 && board[2, 2] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[2, 1] == 0)
+        {
+            if ((board[0, 1] == 1 && board[1, 1] == 1) ||
+                (board[2, 0] == 1 && board[2, 2] == 1))
+            {
+                score += 500;
+            }
+
+            if ((board[0, 1] == 2 && board[1, 1] == 2) ||
+                (board[2, 0] == 2 && board[2, 2] == 2))
+            {
+                score -= 500;
+            }
+        }
+        if (board[2, 2] == 0)
+        {
+            if ((board[0, 2] == 1 && board[1, 2] == 1) ||
+                (board[2, 0] == 1 && board[2, 1] == 1))
+            {
+                score += 500;
+            }
+
+            if ((board[0, 2] == 2 && board[1, 2] == 2) ||
+                (board[2, 0] == 2 && board[2, 1] == 2))
+            {
+                score -= 500;
+            }
+        }
+        
         return Math.Clamp(score, -1000, 1000);
-    }
-
-    private static int TwoInRowScore(int a, int b, int c)
-    {
-        if ((a == 0 && b == 1 && c == 1) ||
-            (a == 1 && b == 0 && c == 1) ||
-            (a == 1 && b == 1 && c == 0))
-        {
-            return 500;
-        }
-
-        if ((a == 0 && b == 2 && c == 2) ||
-            (a == 2 && b == 0 && c == 2) ||
-            (a == 2 && b == 2 && c == 0))
-        {
-            return -500;
-        }
-
-        return 0;
     }
 }


### PR DESCRIPTION
## Summary

Provide a short description of the change and why it is needed.

## Related Issue

Fixes: # (link issue number or leave blank)

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Performance
- [x] Tests

## Description of Changes

Fixed the halfdepth evalutor because if we have 2 time a 2 in a row that point to the same square that counts as one. because one defensive move fixes that.

## Verification Steps

How can reviewers validate the change locally? Include commands and expected output where applicable.

- Build / run commands:
- Endpoints or code paths exercised:
- Test commands:

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and followed the guidelines.
- [x] Changes are covered by tests where applicable.
- [x] Documentation updated (if applicable).
- [x] The build passes locally and in CI.

## Notes for Reviewers

Any context that will help reviewers (design decisions, trade-offs, follow-ups).

## Breaking Changes

List breaking changes, migration notes, or backwards-incompatible behavior.

---

Thanks for contributing — please be kind and constructive during the review.
