### PR TITLE
Suggestion: simplify API endpoints

### DIFF
--- a/src/backend/TikTakToe/Controllers/EngineLookupController.cs
+++ b/src/backend/TikTakToe/Controllers/EngineLookupController.cs
@@ -20,7 +20,7 @@ public static class EngineLookupController
         .WithName("ListEngineCapabilities")
         .WithSummary("Lists all engines and their capabilities");
 
-        app.MapGet("/engines/resolve-display-name/{id:guid}", async (Guid id, IEngineLookupProvider provider, CancellationToken cancellationToken) =>
+        app.MapGet("/engines/{id:guid}", async (Guid id, IEngineLookupProvider provider, CancellationToken cancellationToken) =>
         {
             await provider.EnsureCapabilitiesAsync(cancellationToken);
             var capability = await provider.GetByIdAsync(id, cancellationToken);
@@ -31,8 +31,22 @@ public static class EngineLookupController
 
             return Results.Ok(ApiResponse<EngineIdLookupDto>.Ok(new EngineIdLookupDto(capability.Id, capability.PlayerId, capability.DisplayName)));
         })
-        .WithName("ResolveEngineDisplayName")
-        .WithSummary("Converts engine id to display name");
+        .WithName("GetEngineById")
+        .WithSummary("Gets engine details by id");
+
+        app.MapGet("/engines/{displayName}", async (string displayName, IEngineLookupProvider provider, CancellationToken cancellationToken) =>
+        {
+            await provider.EnsureCapabilitiesAsync(cancellationToken);
+            var capability = await provider.GetByDisplayNameAsync(displayName, cancellationToken);
+            if (capability is null)
+            {
+                return Results.NotFound(ApiResponse<EngineIdLookupDto>.Fail("Engine display name not found."));
+            }
+
+            return Results.Ok(ApiResponse<EngineIdLookupDto>.Ok(new EngineIdLookupDto(capability.Id, capability.PlayerId, capability.DisplayName)));
+        })
+        .WithName("GetEngineByDisplayName")
+        .WithSummary("Gets engine details by display name");
 
         app.MapGet("/engines/resolve-engine-id/{playerId:guid}", async (Guid playerId, IEngineLookupProvider provider, CancellationToken cancellationToken) =>
         {
@@ -47,20 +61,6 @@ public static class EngineLookupController
         })
         .WithName("ResolveEngineIdByPlayerId")
         .WithSummary("Converts engine player id to engine id");
-
-        app.MapGet("/engines/resolve-id", async (string displayName, IEngineLookupProvider provider, CancellationToken cancellationToken) =>
-        {
-            await provider.EnsureCapabilitiesAsync(cancellationToken);
-            var capability = await provider.GetByDisplayNameAsync(displayName, cancellationToken);
-            if (capability is null)
-            {
-                return Results.NotFound(ApiResponse<EngineIdLookupDto>.Fail("Engine display name not found."));
-            }
-
-            return Results.Ok(ApiResponse<EngineIdLookupDto>.Ok(new EngineIdLookupDto(capability.Id, capability.PlayerId, capability.DisplayName)));
-        })
-        .WithName("ResolveEngineId")
-        .WithSummary("Converts display name to engine id");
     }
 
     private sealed record EngineCapabilityDto(Guid Id, Guid PlayerId, string DisplayName, int MaxBoardSizeX, int MaxBoardSizeY, bool Depth);


### PR DESCRIPTION
## Summary

Simplify the API endpoints by using unified endpoint.

## Related Issue

Fixes: #

## Type of Change

- [ ] Bugfix
- [X] New feature
- [ ] Documentation
- [X] Refactor
- [ ] Performance
- [ ] Tests

## Description of Changes

Combined the /engines, /engines/resolve-display-name/{id:guid}, and /engines/resolve-id into one /engines endpoint with the following behaviour:
- /engines => same as before
- /engines/{GUID} => get engine by GUID
- /engines/{NORMALIZED_DISPLAY_NAME}  

## Verification Steps

Run backend and check scalar

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) and followed the guidelines.
- [ ] Changes are covered by tests where applicable.
- [ ] Documentation updated (if applicable).
- [X] The build passes locally and in CI.

## Breaking Changes

Unsure of breaking changes, all tests succeed. 
